### PR TITLE
Request fetching local block in blinded format

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -32,6 +32,7 @@ FLAGS="validator \
     --doppelgangerProtection=${DOPPELGANGER_PROTECTION} \
     --beaconNodes=${BEACON_API_URL} \
     --http.requestWireFormat=ssz \
+    --blindedLocal true \
     --logLevel=${LOG_LEVEL} \
     --logFileLevel=debug \
     --logFileDailyRotate 5 \


### PR DESCRIPTION
This configures the vc to request a local block in blinded format. This can safely be enabled on dappnode as users are just connected to a single beacon node. For multi-node setups this is not recommended as vc must publish block to the same node that produced it.