### PR TITLE
Update auto_check.yml: bump checkout to v6 and use dedicated PR token

### DIFF
--- a/.github/workflows/auto-check.yml
+++ b/.github/workflows/auto-check.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npx @dappnode/dappnodesdk github-action bump-upstream --use_variants
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DAPPNODE_ACTIONS_PR_CREATOR }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
           PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}


### PR DESCRIPTION
Updates the auto_check workflow to use the latest checkout action and a dedicated token for PR creation.

## Changes

- Bump `actions/checkout@v4` → `v6`
- Use `secrets.DAPPNODE_ACTIONS_PR_CREATOR` instead of `secrets.GITHUB_TOKEN` for the workflow token

```diff
- - uses: actions/checkout@v4
+ - uses: actions/checkout@v6
  - run: npx @dappnode/dappnodesdk github-action bump-upstream --use_variants
    env:
-     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+     GITHUB_TOKEN: ${{ secrets.DAPPNODE_ACTIONS_PR_CREATOR }}
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Repository: dappnode/DAppNodePackage-prysm-generic
> 
> Create a pull request updating `.github/workflows/auto_check.yml` with:
> 1) Bump `actions/checkout` to `v6`.
> 2) Set env `GITHUB_TOKEN` to `${{ secrets.DAPPNODE_ACTIONS_PR_CREATOR }}`.
> 
> Acceptance criteria:
> - Only `.github/workflows/auto_check.yml` is changed unless strictly necessary.
> - YAML remains valid.
> - PR title/description summarize both changes.


</details>