### PR TITLE
feat: add onchain release sync workflow

### DIFF
--- a/.github/workflows/onchain-release-sync.yml
+++ b/.github/workflows/onchain-release-sync.yml
@@ -1,0 +1,15 @@
+name: Onchain Release Sync
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+      - "main"
+
+jobs:
+  onchain-release-sync:
+    uses: dappnode/workflows/.github/workflows/onchain-release-sync.yml@master
+    secrets: inherit


### PR DESCRIPTION
Adds the `onchain-release-sync` reusable workflow from [dappnode/workflows](https://github.com/dappnode/workflows/blob/master/.github/workflows/onchain-release-sync.yml), similar to the existing bump-upstream workflow.