### PR TITLE
Add TropiBot attestation dispatch workflow

### DIFF
--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -1,0 +1,24 @@
+name: Proof of Attestation
+
+on:
+  repository_dispatch:
+    types: [tropibot-attestation-test]
+  workflow_dispatch:
+    inputs:
+      execution_client:
+        description: "Execution Client"
+        required: true
+        type: choice
+        options: [geth, nethermind, besu, erigon, reth]
+
+jobs:
+  attestation-test:
+    uses: dappnode/workflows/.github/workflows/staking-attestation-test.yml@master
+    with:
+      package_variant: "hoodi"
+      consensus_client: ${{ github.event.client_payload.consensus_client || 'lodestar' }}
+      execution_client: ${{ github.event.client_payload.execution_client || inputs.execution_client || '' }}
+      pr_number: ${{ github.event.client_payload.pr_number || '' }}
+      head_ref: ${{ github.event.client_payload.head_ref || github.ref }}
+      sender: ${{ github.event.client_payload.sender || github.actor }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add an attestation workflow triggered by TropiBot repository dispatch
- Wire Lodestar defaults into the reusable staking attestation workflow
- Avoid duplicate push or pull_request triggers

## Validation
- Parsed workflow YAML locally