### PR TITLE
ci: add tropibot repository_dispatch + metadata to sync-test, align attestation-test with org spec

### DIFF
--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -15,10 +15,9 @@ jobs:
   attestation-test:
     uses: dappnode/workflows/.github/workflows/staking-attestation-test.yml@master
     with:
-      package_variant: "hoodi"
-      consensus_client: ${{ github.event.client_payload.consensus_client || 'lodestar' }}
+      consensus_client: "lodestar"
       execution_client: ${{ github.event.client_payload.execution_client || inputs.execution_client || '' }}
-      pr_number: ${{ github.event.client_payload.pr_number || '' }}
-      head_ref: ${{ github.event.client_payload.head_ref || github.ref }}
-      sender: ${{ github.event.client_payload.sender || github.actor }}
+      pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
+      head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
+      sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
     secrets: inherit

--- a/.github/workflows/attestation-test.yml
+++ b/.github/workflows/attestation-test.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: choice
         options: [geth, nethermind, besu, erigon, reth]
+      ipfs_hash:
+        description: "Optional pre-built IPFS hash to test against"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   attestation-test:
@@ -20,4 +25,5 @@ jobs:
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
+      ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: choice
         options: [geth, nethermind, besu, erigon, reth]
+      ipfs_hash:
+        description: "Optional pre-built IPFS hash to test against"
+        required: false
+        type: string
+        default: ""
   pull_request:
     branches:
       - "main"
@@ -25,4 +30,5 @@ jobs:
       pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
       head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
       sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
+      ipfs_hash: ${{ github.event.client_payload.ipfs_hash || inputs.ipfs_hash || '' }}
     secrets: inherit

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -1,6 +1,8 @@
 name: Execution Client Sync Test
 
 on:
+  repository_dispatch:
+    types: [tropibot-sync-test]
   workflow_dispatch:
     inputs:
       execution_client:
@@ -19,5 +21,8 @@ jobs:
     uses: dappnode/workflows/.github/workflows/staking-sync-test.yml@master
     with:
       consensus_client: "lodestar"
-      execution_client: ${{ inputs.execution_client || '' }}
+      execution_client: ${{ github.event.client_payload.execution_client || inputs.execution_client || '' }}
+      pr_number: ${{ github.event.client_payload.pr_number || github.event.pull_request.number || '' }}
+      head_ref: ${{ github.event.client_payload.head_ref || github.event.pull_request.head.ref || github.ref_name }}
+      sender: ${{ github.event.client_payload.sender || github.event.pull_request.user.login || github.actor }}
     secrets: inherit


### PR DESCRIPTION
Wires the staker package test workflows into the TropiBot dispatch flow and aligns lodestar's existing attestation-test.yml with the org spec.

**sync-test.yml**
- Add `repository_dispatch` trigger for `tropibot-sync-test`.
- Forward `pr_number`, `head_ref`, and `sender` from the dispatch payload (with `pull_request` and `github.*` fallbacks) to the reusable `dappnode/workflows/.github/workflows/staking-sync-test.yml@master`.
- Keep existing `workflow_dispatch` and `pull_request` triggers.

**attestation-test.yml**
- Hard-code `consensus_client: "lodestar"` (was `... || 'lodestar'`).
- Remove the redundant `package_variant: "hoodi"` (reusable workflow defaults to hoodi, so behavior is unchanged).
- Align metadata mapping (`pr_number` / `head_ref` / `sender` fallbacks) with sync-test.yml for consistency.